### PR TITLE
bug fix

### DIFF
--- a/lua/betterchat/client/sidepanel/panels/members.lua
+++ b/lua/betterchat/client/sidepanel/panels/members.lua
@@ -148,7 +148,7 @@ function chatBox.generateGroupMemberMenu(panel, group)
 		local ply = player.GetBySteamID(id)
 		if ply then
 			local chatEnabled = chatBox.playerSettings[id] and chatBox.playerSettings[id].isChatEnabled or false
-			p(chatBox.playerSettings[id])
+			--p(chatBox.playerSettings[id])
 			if not chatEnabled then 
 				setting.nameColor = Color(255,0,0)
 				setting.extra = setting.extra .. ". This person currently has BetterChat disabled"


### PR DESCRIPTION
By disabling this line i no longer get this error while tryin to create a group


[ERROR] addons/better-chat/lua/betterchat/client/sidepanel/panels/members.lua:151: attempt to call global 'p' (a nil value)
  1. generateGroupMemberMenu - addons/better-chat/lua/betterchat/client/sidepanel/panels/members.lua:151
   2. reloadGroupMemberMenu - addons/better-chat/lua/betterchat/client/sidepanel/panels/members.lua:45
    3. OnSelect - addons/better-chat/lua/betterchat/client/channels/groupchannels.lua:120
     4. ChooseOption - lua/vgui/dcombobox.lua:95
      5. DoClick - lua/vgui/dcombobox.lua:187
       6. OnMouseReleased - lua/vgui/dlabel.lua:234
        7. unknown - lua/vgui/dmenuoption.lua:77