### PR TITLE
Fix boolean error

### DIFF
--- a/lua/betterchat/server/sv_manager.lua
+++ b/lua/betterchat/server/sv_manager.lua
@@ -239,7 +239,7 @@ end )
 function bc.manager.sendTeamOverload( ply, msg )
     if not bc.settings.getServerValue( "replaceTeam" ) then return end
 
-    msg = bc.manager.trimMessage( msg )
+    msg = bc.manager.trimMessage( tostring( msg ) )
 
     local t = ply:Team()
     local plys = team.GetPlayers( t )


### PR DESCRIPTION
```
addons/betterchat/lua/betterchat/server/sv_manager.lua:103: attempt to get length of local 'msg' (a boolean value)
   0.  __len - [C]:-1
    1.  trimMessage - addons/betterchat/lua/betterchat/server/sv_manager.lua:103
     2.  fn - addons/betterchat/lua/betterchat/server/sv_manager.lua:50
      3.  Run - addons/ulib/lua/ulib/shared/hook.lua:109
       4.  fn - addons/betterchat/lua/betterchat/shared/sh_util.lua:205
        5.  Run - addons/ulib/lua/ulib/shared/hook.lua:109
         6.  unkown - addons/betterchat/lua/betterchat/server/sv_manager.lua:114
```